### PR TITLE
Support to skip creating db if directory already exists

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -46,6 +46,8 @@ impl Log {
         if create {
             if path.exists() && !path.is_dir() {
                 return Err(Error::InvalidPath(path_str.to_string()));
+            } else if path.exists() && path.is_dir() {
+                warn!("{} is already exists. Skip to create.", path_str);
             } else if !path.exists() {
                 fs::create_dir(&path)?;
             }


### PR DESCRIPTION
When we set `.create(true)` but db directory already exists, cask does
not start. Thus, the first run with `create(true)` works fine, but the
second run always fail.

This patch changes cask's behavior to use existing directory in the
`create(true)` condition by just skipping to create the directory.