### PR TITLE
Bump byteorder to 1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 keywords = ["database", "db", "key-value", "kv"]
 
 [dependencies]
-byteorder = "~1.0.0"
+byteorder = "~1.2.0"
 fs2 = "~0.4.1"
 lazy_static = "~0.2.8"
 log = "~0.3.7"


### PR DESCRIPTION
I cannot compile cask when using reqwest 0.8.5

Lets bump the version to 1.2?

>     Updating registry `https://github.com/rust-lang/crates.io-index`
>     error: failed to select a version for `byteorder` (required by `cask`):         
>     all possible versions conflict with previously selected versions of `byteorder`
>     version 1.2.1 in use by byteorder v1.2.1
>     possible versions to select: 1.0.0
