### PR TITLE
unnecessary #[allow(unused_variables)]

### DIFF
--- a/src/cask.rs
+++ b/src/cask.rs
@@ -553,8 +553,7 @@ impl Cask {
 
     /// Trigger `Cask` log compaction.
     pub fn compact(&self) -> Result<()> {
-        #[allow(unused_variables)]
-        let lock = self.compaction.lock().unwrap();
+        let _lock = self.compaction.lock().unwrap();
 
         let active_file_id = {
             self.inner.read().unwrap().log.active_file_id
@@ -662,7 +661,6 @@ impl Cask {
 impl Drop for Cask {
     fn drop(&mut self) {
         self.dropped.store(true, Ordering::SeqCst);
-        #[allow(unused_variables)]
-        let lock = self.compaction.lock().unwrap();
+        let _lock = self.compaction.lock().unwrap();
     }
 }


### PR DESCRIPTION
You do not need to use the `#[allow(unused_variables)]` before a variable that you don't use to avoid getting a warning. You can simply add an underscore before the name of the var and it does the exact same thing. Try it out!