### PR TITLE
Replaced the #[allow(unused_variables)]

### DIFF
--- a/src/cask.rs
+++ b/src/cask.rs
@@ -553,8 +553,7 @@ impl Cask {
 
     /// Trigger `Cask` log compaction.
     pub fn compact(&self) -> Result<()> {
-        #[allow(unused_variables)]
-        let lock = self.compaction.lock().unwrap();
+        let _lock = self.compaction.lock().unwrap();
 
         let active_file_id = {
             self.inner.read().unwrap().log.active_file_id
@@ -662,7 +661,6 @@ impl Cask {
 impl Drop for Cask {
     fn drop(&mut self) {
         self.dropped.store(true, Ordering::SeqCst);
-        #[allow(unused_variables)]
-        let lock = self.compaction.lock().unwrap();
+        let _lock = self.compaction.lock().unwrap();
     }
 }


### PR DESCRIPTION
You do not need to use #[allow(unused_variables)] to avoid compiler warnings. You can just add an underscore beforet the name of the variable and it does the same thing. Try it out!